### PR TITLE
20 technicaldebt standardize api endpoint paths across routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ library/
 
 2. Running the services:
    ```sh
-   docker-compose up --build
+   docker compose up --build
    ```
 
 3. The FastAPI is available at `http://localhost:8000`.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/app/routers/customers.py
+++ b/app/routers/customers.py
@@ -22,18 +22,14 @@ async def get_user_by_id(user_id: int, db: AsyncSession = Depends(get_db)):
     return await customer_service.get_user(user_id, db)
 
 
-@router.get("/users/", response_model=List[Customer])
-async def get_all_authors(
-    skip: int = 0, limit: int = 50, db: AsyncSession = Depends(get_db)
-):
-    return await customer_service.get_all_users(True, db, skip, limit)
-
-
 @router.get("/users", response_model=List[Customer])
 async def get_all_users(
-    skip: int = 0, limit: int = 50, db: AsyncSession = Depends(get_db)
+    is_author: bool = False,
+    skip: int = 0,
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
 ):
-    return await customer_service.get_all_users(False, db, skip, limit)
+    return await customer_service.get_all_users(is_author, db, skip, limit)
 
 
 @router.put("/users/{user_id}", response_model=Customer)


### PR DESCRIPTION
Fixed a mistake in `docker compose up --build`, removes useless endpoint, minor fixes.